### PR TITLE
Move Switch Direction button between result cards with vertical arrows

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -63,26 +63,6 @@ struct ContentView: View {
                                 Text("Powered by Groq AI")
                                     .font(.subheadline)
                                     .foregroundColor(.secondary)
-
-                                // Direction toggle button
-                                Button(action: {
-                                    withAnimation {
-                                        translationDirection = translationDirection == .creoleToEnglish ? .englishToCreole : .creoleToEnglish
-                                    }
-                                }) {
-                                    HStack(spacing: 8) {
-                                        Image(systemName: "arrow.left.arrow.right")
-                                            .font(.system(size: 14))
-                                        Text("Switch Direction")
-                                            .font(.subheadline)
-                                    }
-                                    .padding(.horizontal, 16)
-                                    .padding(.vertical, 8)
-                                    .background(Color(UIColor.secondarySystemBackground))
-                                    .foregroundColor(.accentColor)
-                                    .cornerRadius(20)
-                                }
-                                .disabled(isProcessing)
                             }
 
                             Spacer()
@@ -216,6 +196,26 @@ struct ContentView: View {
                     },
                     isSpeaking: ttsManager.isSpeaking && speakingCardTitle == "source"
                 )
+
+                // Switch Direction button between the two cards
+                Button(action: {
+                    withAnimation {
+                        translationDirection = translationDirection == .creoleToEnglish ? .englishToCreole : .creoleToEnglish
+                    }
+                }) {
+                    HStack(spacing: 8) {
+                        Image(systemName: "arrow.up.arrow.down")
+                            .font(.system(size: 14))
+                        Text("Switch Direction")
+                            .font(.subheadline)
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 8)
+                    .background(Color(UIColor.secondarySystemBackground))
+                    .foregroundColor(.accentColor)
+                    .cornerRadius(20)
+                }
+                .disabled(isProcessing)
 
                 // Target language card
                 let targetLanguage = translationDirection == .creoleToEnglish ? "en-US" : "ht-HT"


### PR DESCRIPTION
## Summary

- Moved the Switch Direction button from the header to between the two language result cards, so it sits visually between what it controls
- Changed arrow icon from horizontal (`arrow.left.arrow.right`) to vertical (`arrow.up.arrow.down`) to match the layout

## Test plan

- [ ] Build and run
- [ ] Confirm button no longer appears in the header
- [ ] Confirm button appears between the source and target language cards
- [ ] Confirm arrows point up and down
- [ ] Confirm tapping still toggles translation direction correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)