### PR TITLE
Increase ad load: interstitials every 4 translations + rewarded voice unlock

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -33,7 +33,6 @@ struct ContentView: View {
     @State private var speakingCardTitle: String? = nil
     @State private var typedInput = ""
     @State private var inputMode: InputMode = .voice
-    @State private var sessionTranslationCount = 0
 
     enum InputMode {
         case voice, text
@@ -414,10 +413,7 @@ struct ContentView: View {
                     statusMessage = "✅ Completed using \(result.provider)"
                     isProcessing = false
                     historyManager.addEntry(source: result.transcription, translated: result.translation, direction: result.direction)
-                    sessionTranslationCount += 1
-                    if sessionTranslationCount % InterstitialAdManager.interstitialInterval == 0 {
-                        interstitialAd.showIfReady()
-                    }
+                    interstitialAd.translationCompleted()
                 }
             } catch {
                 await MainActor.run {
@@ -454,10 +450,7 @@ struct ContentView: View {
                     statusMessage = "✅ Completed using \(result.provider)"
                     isProcessing = false
                     historyManager.addEntry(source: result.transcription, translated: result.translation, direction: result.direction)
-                    sessionTranslationCount += 1
-                    if sessionTranslationCount % InterstitialAdManager.interstitialInterval == 0 {
-                        interstitialAd.showIfReady()
-                    }
+                    interstitialAd.translationCompleted()
                 }
 
                 // Clean up audio file

--- a/ContentView.swift
+++ b/ContentView.swift
@@ -5,6 +5,7 @@
 //  Main UI for Creole to English Translator
 //
 
+import FirebaseAnalytics
 import SwiftUI
 
 struct ContentView: View {
@@ -83,6 +84,11 @@ struct ContentView: View {
                                     withAnimation {
                                         showHistory.toggle()
                                     }
+                                    if showHistory {
+                                        Analytics.logEvent(AnalyticsEventScreenView, parameters: [
+                                            AnalyticsParameterScreenName: "history",
+                                        ])
+                                    }
                                 }) {
                                     ZStack {
                                         Circle()
@@ -101,7 +107,12 @@ struct ContentView: View {
                                         .foregroundColor(.secondary)
                                 }
 
-                                Button(action: { showSettings = true }) {
+                                Button(action: {
+                                    showSettings = true
+                                    Analytics.logEvent(AnalyticsEventScreenView, parameters: [
+                                        AnalyticsParameterScreenName: "settings",
+                                    ])
+                                }) {
                                     ZStack {
                                         Circle()
                                             .fill(Color(UIColor.secondarySystemBackground))
@@ -413,6 +424,7 @@ struct ContentView: View {
                     statusMessage = "✅ Completed using \(result.provider)"
                     isProcessing = false
                     historyManager.addEntry(source: result.transcription, translated: result.translation, direction: result.direction)
+                    logTranslationEvent("translation_completed", inputMode: "text")
                     interstitialAd.translationCompleted()
                 }
             } catch {
@@ -422,9 +434,17 @@ struct ContentView: View {
                     errorMessage = "Error: \(error.localizedDescription)"
                     statusMessage = ""
                     isProcessing = false
+                    logTranslationEvent("translation_failed", inputMode: "text")
                 }
             }
         }
+    }
+
+    private func logTranslationEvent(_ name: String, inputMode: String) {
+        Analytics.logEvent(name, parameters: [
+            "direction": translationDirection == .creoleToEnglish ? "creole_to_english" : "english_to_creole",
+            "input_mode": inputMode,
+        ])
     }
 
     private func processAudio(url: URL) {
@@ -450,6 +470,7 @@ struct ContentView: View {
                     statusMessage = "✅ Completed using \(result.provider)"
                     isProcessing = false
                     historyManager.addEntry(source: result.transcription, translated: result.translation, direction: result.direction)
+                    logTranslationEvent("translation_completed", inputMode: "voice")
                     interstitialAd.translationCompleted()
                 }
 
@@ -463,6 +484,7 @@ struct ContentView: View {
                     errorMessage = "Error: \(error.localizedDescription)"
                     statusMessage = ""
                     isProcessing = false
+                    logTranslationEvent("translation_failed", inputMode: "voice")
                 }
 
                 // Clean up audio file

--- a/ContentView.swift
+++ b/ContentView.swift
@@ -148,7 +148,12 @@ struct ContentView: View {
                 }
             }
             .onAppear {
-                checkMicrophonePermission()
+                // Returning users never see the consent sheet, so ask ATT
+                // here; first-run users get it after the sheet (see below).
+                // Resolving ATT early keeps banner requests personalized.
+                if privacyConsent.hasConsented {
+                    ATTAuthorization.requestIfNeeded()
+                }
                 // Warn user if API key is missing so they know to add it before using the network features.
                 if groqAPIKey == nil {
                     errorMessage = "Missing Groq API key. Add GROQ_API_KEY to a gitignored Secrets.plist or set the GROQ_API_KEY environment variable in your Xcode scheme. See README for setup."
@@ -173,6 +178,9 @@ struct ContentView: View {
             set: { _ in }
         )) {
             DataPrivacyConsentView(consentManager: privacyConsent)
+        }
+        .onChange(of: privacyConsent.hasConsented) { consented in
+            if consented { ATTAuthorization.requestIfNeeded() }
         }
     }
     
@@ -210,7 +218,7 @@ struct ContentView: View {
                     .cornerRadius(15)
                     .shadow(color: .black.opacity(0.2), radius: 10, y: 5)
                 }
-                .disabled(isProcessing || !permissionGranted || !privacyConsent.hasConsented)
+                .disabled(isProcessing || !privacyConsent.hasConsented)
                 .padding(.horizontal, 30)
             } else {
                 // Text input
@@ -368,19 +376,19 @@ struct ContentView: View {
         }
     }
     
-    private func checkMicrophonePermission() {
-        audioRecorder.requestPermission { granted in
-            permissionGranted = granted
-            if !granted {
-                errorMessage = "Microphone access denied. Please enable it in Settings."
-            }
-        }
-    }
-    
     private func startRecording() {
         errorMessage = nil
-        statusMessage = "🔴 Recording..."
-        recordingURL = audioRecorder.startRecording()
+        // Ask for mic access on first record tap — in context, the user
+        // understands exactly why the prompt is appearing.
+        audioRecorder.requestPermission { granted in
+            permissionGranted = granted
+            guard granted else {
+                errorMessage = "Microphone access denied. Please enable it in Settings."
+                return
+            }
+            statusMessage = "🔴 Recording..."
+            recordingURL = audioRecorder.startRecording()
+        }
     }
     
     private func stopRecording() {

--- a/ContentView.swift
+++ b/ContentView.swift
@@ -127,7 +127,7 @@ struct ContentView: View {
                                 Spacer()
                             }
                             .sheet(isPresented: $showSettings) {
-                                SettingsView(voiceSettings: voiceSettings, ttsManager: ttsManager)
+                                SettingsView(voiceSettings: voiceSettings, ttsManager: ttsManager, privacyConsent: privacyConsent)
                             }
                         }
                         .padding(.horizontal)
@@ -433,7 +433,7 @@ struct ContentView: View {
                     isProcessing = false
                     historyManager.addEntry(source: result.transcription, translated: result.translation, direction: result.direction)
                     logTranslationEvent("translation_completed", inputMode: "text")
-                    interstitialAd.translationCompleted()
+                    interstitialAd.translationCompleted(isSpeaking: ttsManager.isSpeaking)
                 }
             } catch {
                 await MainActor.run {
@@ -479,7 +479,7 @@ struct ContentView: View {
                     isProcessing = false
                     historyManager.addEntry(source: result.transcription, translated: result.translation, direction: result.direction)
                     logTranslationEvent("translation_completed", inputMode: "voice")
-                    interstitialAd.translationCompleted()
+                    interstitialAd.translationCompleted(isSpeaking: ttsManager.isSpeaking)
                 }
 
                 // Clean up audio file

--- a/CreoleTranslator.xcodeproj/project.pbxproj
+++ b/CreoleTranslator.xcodeproj/project.pbxproj
@@ -336,7 +336,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.92;
+				MARKETING_VERSION = 2.95;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jbaker.CreoleTranslator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -434,7 +434,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.92;
+				MARKETING_VERSION = 2.95;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jbaker.CreoleTranslator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/CreoleTranslator.xcodeproj/project.pbxproj
+++ b/CreoleTranslator.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		AA000001000000000000AAA1 /* VoiceSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000001000000000000AAA2 /* VoiceSettings.swift */; };
 		AA000002000000000000AAA1 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000002000000000000AAA2 /* SettingsView.swift */; };
 		AA000003000000000000AAA1 /* InterstitialAdManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000003000000000000AAA2 /* InterstitialAdManager.swift */; };
+		AA000042000000000000AAA1 /* RewardedAdManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000042000000000000AAA2 /* RewardedAdManager.swift */; };
 		B5E4AE585D6E921238B11EAC /* AudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06119D5B37214D87C744768B /* AudioRecorder.swift */; };
 		D098CFC275F05E49EC77DAE8 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E95F2CDE1F40D7EBB31663A /* ContentView.swift */; };
 		DCDFF919BA2707095807DDC7 /* CreoleTranslatorApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BCDA7F3495F3212FD98EBB0 /* CreoleTranslatorApp.swift */; };
@@ -66,6 +67,7 @@
 		AA000001000000000000AAA2 /* VoiceSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceSettings.swift; sourceTree = "<group>"; };
 		AA000002000000000000AAA2 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		AA000003000000000000AAA2 /* InterstitialAdManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterstitialAdManager.swift; sourceTree = "<group>"; };
+		AA000042000000000000AAA2 /* RewardedAdManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardedAdManager.swift; sourceTree = "<group>"; };
 		AFFF8A76EBBF12B6FEAA3808 /* GroqService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroqService.swift; sourceTree = "<group>"; };
 		C960AD91973A4D9DA5E60BB9 /* DataPrivacyConsent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataPrivacyConsent.swift; sourceTree = "<group>"; };
 		DBD1399329CE637BF2B7F42D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -118,6 +120,7 @@
 				AA000001000000000000AAA2 /* VoiceSettings.swift */,
 				AA000002000000000000AAA2 /* SettingsView.swift */,
 				AA000003000000000000AAA2 /* InterstitialAdManager.swift */,
+				AA000042000000000000AAA2 /* RewardedAdManager.swift */,
 				83684C00265DAE85836F7BFF /* Assets.xcassets */,
 				6ED7AC792F302BA6000E65B1 /* Docs */,
 				6EE149092F300F0A00CFE9BA /* scripts */,
@@ -300,6 +303,7 @@
 				AA000001000000000000AAA1 /* VoiceSettings.swift in Sources */,
 				AA000002000000000000AAA1 /* SettingsView.swift in Sources */,
 				AA000003000000000000AAA1 /* InterstitialAdManager.swift in Sources */,
+				AA000042000000000000AAA1 /* RewardedAdManager.swift in Sources */,
 				6EF0A0B1C2D3E4F500000002 /* OpenAITTSService.swift in Sources */,
 				DCDFF919BA2707095807DDC7 /* CreoleTranslatorApp.swift in Sources */,
 			);

--- a/CreoleTranslatorApp.swift
+++ b/CreoleTranslatorApp.swift
@@ -11,23 +11,18 @@ import FirebaseCore
 
 @main
 struct CreoleTranslatorApp: App {
-    @Environment(\.scenePhase) private var scenePhase
-    
     init() {
         // Firebase must be configured before any other Firebase service
         FirebaseApp.configure()
         // Initialize Google Mobile Ads SDK
         MobileAds.shared.start { status in }
     }
-    
+
     var body: some Scene {
         WindowGroup {
             ContentView()
         }
-        .onChange(of: scenePhase) { newPhase in
-            if newPhase == .active {
-                ATTAuthorization.requestIfNeeded() 
-            }
-        }
+        // ATT is requested from ContentView after the privacy consent
+        // sheet is answered, so first-launch dialogs don't stack.
     }
 }

--- a/DataPrivacyConsent.swift
+++ b/DataPrivacyConsent.swift
@@ -26,6 +26,12 @@ class DataPrivacyConsent: ObservableObject {
         hasConsented = true
     }
 
+    // The privacy policy promises consent can be revoked in Settings —
+    // this backs that promise. Revoking re-presents the consent sheet.
+    func revokeConsent() {
+        hasConsented = false
+    }
+
     var shouldShowConsentDialog: Bool {
         return !hasConsented
     }
@@ -45,7 +51,7 @@ struct DataPrivacyConsentView: View {
                 .font(.title3)
                 .fontWeight(.bold)
 
-            Text("Your speech is sent to Groq AI for transcription and translation. Audio is processed temporarily and never stored.")
+            Text("Your speech is sent to Groq AI for transcription and translation, and translated text is sent to OpenAI to generate spoken audio. Audio is processed temporarily and never stored; translations are saved only on your device.")
                 .font(.subheadline)
                 .foregroundColor(.secondary)
                 .multilineTextAlignment(.center)
@@ -89,7 +95,7 @@ private struct ConsentSheetPresentation: ViewModifier {
     func body(content: Content) -> some View {
         if #available(iOS 16, *) {
             content
-                .presentationDetents([.height(360)])
+                .presentationDetents([.height(400)])
                 .presentationDragIndicator(.visible)
         } else {
             content

--- a/DataPrivacyConsent.swift
+++ b/DataPrivacyConsent.swift
@@ -26,10 +26,6 @@ class DataPrivacyConsent: ObservableObject {
         hasConsented = true
     }
 
-    func revokeConsent() {
-        hasConsented = false
-    }
-
     var shouldShowConsentDialog: Bool {
         return !hasConsented
     }
@@ -67,22 +63,17 @@ struct DataPrivacyConsentView: View {
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 24)
 
-            VStack(spacing: 10) {
-                Button(action: { consentManager.grantConsent() }) {
-                    Text("Allow & Continue")
-                        .fontWeight(.semibold)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 14)
-                        .background(Color.accentColor)
-                        .foregroundColor(.white)
-                        .cornerRadius(12)
-                }
-
-                Button(action: { consentManager.revokeConsent() }) {
-                    Text("Not Now")
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
-                }
+            // Single honest action: the app cannot function without Groq,
+            // so a decline button that goes nowhere would be a dark pattern
+            // (and an App Store 5.1.1 rejection risk).
+            Button(action: { consentManager.grantConsent() }) {
+                Text("I Understand — Continue")
+                    .fontWeight(.semibold)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 14)
+                    .background(Color.accentColor)
+                    .foregroundColor(.white)
+                    .cornerRadius(12)
             }
             .padding(.horizontal, 24)
 

--- a/Info.plist
+++ b/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -22,40 +20,14 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>GADApplicationIdentifier</key>
+	<string>ca-app-pub-7871017136061682~8037488563</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>This app needs access to your microphone to record Haitian Creole speech for translation.</string>
-	<key>NSSpeechRecognitionUsageDescription</key>
-	<string>This app uses speech recognition to transcribe your Haitian Creole audio.</string>
-	<key>UIApplicationSceneManifest</key>
-	<dict>
-		<key>UIApplicationSupportsMultipleScenes</key>
-		<true/>
-	</dict>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
-	<key>UILaunchScreen</key>
-	<dict/>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>armv7</string>
-	</array>
-	<key>UISupportedInterfaceOrientations</key>
-	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
-	</array>
-	<key>UISupportedInterfaceOrientations~ipad</key>
-	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
-	</array>
-	<key>GADApplicationIdentifier</key>
-	<string>ca-app-pub-7871017136061682~8037488563</string>
 	<key>NSUserTrackingUsageDescription</key>
 	<string>This identifier will be used to deliver personalized ads to you.</string>
 	<key>SKAdNetworkItems</key>
@@ -324,6 +296,32 @@
 			<key>SKAdNetworkIdentifier</key>
 			<string>tl55sbb4fm.skadnetwork</string>
 		</dict>
+	</array>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 </dict>
 </plist>

--- a/InterstitialAdManager.swift
+++ b/InterstitialAdManager.swift
@@ -1,3 +1,4 @@
+import FirebaseAnalytics
 import GoogleMobileAds
 import UIKit
 
@@ -58,6 +59,10 @@ class InterstitialAdManager: NSObject, ObservableObject, FullScreenContentDelega
         ad.present(from: root)
         shownThisSession += 1
         lastShownAt = Date()
+        Analytics.logEvent("interstitial_shown", parameters: [
+            "translation_count": translationCount,
+            "shown_this_session": shownThisSession,
+        ])
     }
 
     // MARK: FullScreenContentDelegate

--- a/InterstitialAdManager.swift
+++ b/InterstitialAdManager.swift
@@ -1,20 +1,36 @@
 import GoogleMobileAds
 import UIKit
 
-// Shows an interstitial ad every interstitialInterval successful translations per session.
-// Replace adUnitID with the real unit ID from your AdMob dashboard before release.
+// Shows an interstitial ad every interstitialInterval successful translations,
+// capped per session and spaced by a minimum time gap so rapid translators
+// aren't hit with back-to-back full-screen ads.
 @MainActor
 class InterstitialAdManager: NSObject, ObservableObject, FullScreenContentDelegate {
 
-    static let interstitialInterval = 25
+    static let interstitialInterval = 4
+    static let maxPerSession = 6
+    static let minSecondsBetweenShows: TimeInterval = 120
 
     private let adUnitID = "ca-app-pub-7871017136061682/1614363987"
 
     private var interstitial: InterstitialAd?
+    private var translationCount = 0
+    private var shownThisSession = 0
+    private var lastShownAt: Date?
 
     override init() {
         super.init()
         preload()
+    }
+
+    /// Call after each successful translation; shows an ad when due.
+    func translationCompleted() {
+        translationCount += 1
+        guard translationCount % Self.interstitialInterval == 0,
+              shownThisSession < Self.maxPerSession,
+              lastShownAt.map({ Date().timeIntervalSince($0) >= Self.minSecondsBetweenShows }) ?? true
+        else { return }
+        showIfReady()
     }
 
     func preload() {
@@ -28,7 +44,7 @@ class InterstitialAdManager: NSObject, ObservableObject, FullScreenContentDelega
         }
     }
 
-    func showIfReady() {
+    private func showIfReady() {
         guard let ad = interstitial,
               let root = UIApplication.shared
                 .connectedScenes
@@ -40,6 +56,8 @@ class InterstitialAdManager: NSObject, ObservableObject, FullScreenContentDelega
             return
         }
         ad.present(from: root)
+        shownThisSession += 1
+        lastShownAt = Date()
     }
 
     // MARK: FullScreenContentDelegate

--- a/InterstitialAdManager.swift
+++ b/InterstitialAdManager.swift
@@ -11,6 +11,9 @@ class InterstitialAdManager: NSObject, ObservableObject, FullScreenContentDelega
     static let interstitialInterval = 4
     static let maxPerSession = 6
     static let minSecondsBetweenShows: TimeInterval = 120
+    // iOS keeps apps alive for days; without this, heavy users hit the
+    // session cap once and never see interstitials again.
+    static let sessionResetAfterBackground: TimeInterval = 30 * 60
 
     private let adUnitID = "ca-app-pub-7871017136061682/1614363987"
 
@@ -18,10 +21,29 @@ class InterstitialAdManager: NSObject, ObservableObject, FullScreenContentDelega
     private var translationCount = 0
     private var shownThisSession = 0
     private var lastShownAt: Date?
+    private var backgroundedAt: Date?
 
     override init() {
         super.init()
         preload()
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(didEnterBackground),
+            name: UIApplication.didEnterBackgroundNotification, object: nil)
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(willEnterForeground),
+            name: UIApplication.willEnterForegroundNotification, object: nil)
+    }
+
+    @objc private func didEnterBackground() {
+        backgroundedAt = Date()
+    }
+
+    @objc private func willEnterForeground() {
+        guard let bg = backgroundedAt,
+              Date().timeIntervalSince(bg) >= Self.sessionResetAfterBackground else { return }
+        translationCount = 0
+        shownThisSession = 0
+        lastShownAt = nil
     }
 
     /// Call after each successful translation; shows an ad when due.
@@ -56,7 +78,16 @@ class InterstitialAdManager: NSObject, ObservableObject, FullScreenContentDelega
             preload()
             return
         }
-        ad.present(from: root)
+        var top = root
+        while let presented = top.presentedViewController { top = presented }
+        ad.present(from: top)
+    }
+
+    // MARK: FullScreenContentDelegate
+
+    // Count and log only when the ad actually reaches the screen, so a
+    // failed presentation doesn't burn a session slot or fake an impression.
+    func adWillPresentFullScreenContent(_ ad: FullScreenPresentingAd) {
         shownThisSession += 1
         lastShownAt = Date()
         Analytics.logEvent("interstitial_shown", parameters: [
@@ -64,8 +95,6 @@ class InterstitialAdManager: NSObject, ObservableObject, FullScreenContentDelega
             "shown_this_session": shownThisSession,
         ])
     }
-
-    // MARK: FullScreenContentDelegate
 
     func adDidDismissFullScreenContent(_ ad: FullScreenPresentingAd) {
         interstitial = nil

--- a/InterstitialAdManager.swift
+++ b/InterstitialAdManager.swift
@@ -19,6 +19,7 @@ class InterstitialAdManager: NSObject, ObservableObject, FullScreenContentDelega
 
     private var interstitial: InterstitialAd?
     private var translationCount = 0
+    private var translationsSinceLastShow = 0
     private var shownThisSession = 0
     private var lastShownAt: Date?
     private var backgroundedAt: Date?
@@ -42,15 +43,20 @@ class InterstitialAdManager: NSObject, ObservableObject, FullScreenContentDelega
         guard let bg = backgroundedAt,
               Date().timeIntervalSince(bg) >= Self.sessionResetAfterBackground else { return }
         translationCount = 0
+        translationsSinceLastShow = 0
         shownThisSession = 0
         lastShownAt = nil
     }
 
     /// Call after each successful translation; shows an ad when due.
-    func translationCompleted() {
+    /// Pass `isSpeaking` so an ad never covers a spoken translation —
+    /// a skipped opportunity retries on the next translation.
+    func translationCompleted(isSpeaking: Bool = false) {
         translationCount += 1
-        guard translationCount % Self.interstitialInterval == 0,
+        translationsSinceLastShow += 1
+        guard translationsSinceLastShow >= Self.interstitialInterval,
               shownThisSession < Self.maxPerSession,
+              !isSpeaking,
               lastShownAt.map({ Date().timeIntervalSince($0) >= Self.minSecondsBetweenShows }) ?? true
         else { return }
         showIfReady()
@@ -89,6 +95,7 @@ class InterstitialAdManager: NSObject, ObservableObject, FullScreenContentDelega
     // failed presentation doesn't burn a session slot or fake an impression.
     func adWillPresentFullScreenContent(_ ad: FullScreenPresentingAd) {
         shownThisSession += 1
+        translationsSinceLastShow = 0
         lastShownAt = Date()
         Analytics.logEvent("interstitial_shown", parameters: [
             "translation_count": translationCount,

--- a/RewardedAdManager.swift
+++ b/RewardedAdManager.swift
@@ -5,7 +5,13 @@ import UIKit
 @MainActor
 class RewardedAdManager: NSObject, ObservableObject, FullScreenContentDelegate {
 
+#if DEBUG
+    // Google sample rewarded unit — new production units can take hours to
+    // start serving, so debug builds use this to always get a fill.
+    private let adUnitID = "ca-app-pub-3940256099942544/1712485313"
+#else
     private let adUnitID = "ca-app-pub-7871017136061682/5611090338"
+#endif
 
     @Published private(set) var isReady = false
 
@@ -23,8 +29,10 @@ class RewardedAdManager: NSObject, ObservableObject, FullScreenContentDelegate {
                 rewardedAd = try await RewardedAd.load(with: adUnitID, request: Request())
                 rewardedAd?.fullScreenContentDelegate = self
                 isReady = true
+                print("[RewardedAd] loaded and ready")
             } catch {
                 isReady = false
+                print("[RewardedAd] failed to load: \(error.localizedDescription)")
             }
         }
     }

--- a/RewardedAdManager.swift
+++ b/RewardedAdManager.swift
@@ -65,6 +65,10 @@ class RewardedAdManager: NSObject, ObservableObject, FullScreenContentDelegate {
         self.onReward = onReward
         self.onDismiss = onDismiss
         self.onPresentFailure = onPresentFailure
+        // One-shot: drop our reference so a re-entrant show() can't
+        // re-present the same ad and overwrite the callbacks above.
+        rewardedAd = nil
+        isReady = false
         ad.present(from: top) { [weak self] in
             self?.onReward?()
             self?.onReward = nil

--- a/RewardedAdManager.swift
+++ b/RewardedAdManager.swift
@@ -1,0 +1,71 @@
+import GoogleMobileAds
+import UIKit
+
+// Rewarded ad shown to unlock premium AI voices for 24 hours (see VoiceSettings).
+@MainActor
+class RewardedAdManager: NSObject, ObservableObject, FullScreenContentDelegate {
+
+    // TODO: replace with a real REWARDED ad unit created in the AdMob console
+    // (no rewarded unit exists yet for pub-7871017136061682). This is Google's
+    // official test ID — it serves test ads and earns nothing.
+    private let adUnitID = "ca-app-pub-3940256099942544/1712485313"
+
+    @Published private(set) var isReady = false
+
+    private var rewardedAd: RewardedAd?
+    private var onReward: (() -> Void)?
+
+    override init() {
+        super.init()
+        preload()
+    }
+
+    func preload() {
+        Task {
+            do {
+                rewardedAd = try await RewardedAd.load(with: adUnitID, request: Request())
+                rewardedAd?.fullScreenContentDelegate = self
+                isReady = true
+            } catch {
+                isReady = false
+            }
+        }
+    }
+
+    /// Shows the rewarded ad. Returns false if no ad is available
+    /// (caller decides whether to grant the unlock anyway).
+    @discardableResult
+    func show(onReward: @escaping () -> Void) -> Bool {
+        guard let ad = rewardedAd,
+              let root = UIApplication.shared
+                .connectedScenes
+                .compactMap({ ($0 as? UIWindowScene)?.windows.first(where: { $0.isKeyWindow }) })
+                .first?
+                .rootViewController
+        else {
+            preload()
+            return false
+        }
+        self.onReward = onReward
+        ad.present(from: root) { [weak self] in
+            self?.onReward?()
+            self?.onReward = nil
+        }
+        return true
+    }
+
+    // MARK: FullScreenContentDelegate
+
+    func adDidDismissFullScreenContent(_ ad: FullScreenPresentingAd) {
+        rewardedAd = nil
+        isReady = false
+        preload()
+    }
+
+    func ad(_ ad: FullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
+        rewardedAd = nil
+        isReady = false
+        onReward = nil
+        preload()
+    }
+}

--- a/RewardedAdManager.swift
+++ b/RewardedAdManager.swift
@@ -18,6 +18,7 @@ class RewardedAdManager: NSObject, ObservableObject, FullScreenContentDelegate {
     private var rewardedAd: RewardedAd?
     private var onReward: (() -> Void)?
     private var onDismiss: (() -> Void)?
+    private var onPresentFailure: (() -> Void)?
 
     override init() {
         super.init()
@@ -41,8 +42,11 @@ class RewardedAdManager: NSObject, ObservableObject, FullScreenContentDelegate {
     /// Shows the rewarded ad. Returns false if no ad is available
     /// (caller decides whether to grant the unlock anyway).
     /// `onDismiss` fires after the ad closes — safe point to present UI.
+    /// `onPresentFailure` fires if the SDK could not put the ad on screen.
     @discardableResult
-    func show(onReward: @escaping () -> Void, onDismiss: (() -> Void)? = nil) -> Bool {
+    func show(onReward: @escaping () -> Void,
+              onDismiss: (() -> Void)? = nil,
+              onPresentFailure: (() -> Void)? = nil) -> Bool {
         guard let ad = rewardedAd,
               let root = UIApplication.shared
                 .connectedScenes
@@ -53,9 +57,15 @@ class RewardedAdManager: NSObject, ObservableObject, FullScreenContentDelegate {
             preload()
             return false
         }
+        // Present from the top-most VC — the root is usually already
+        // presenting the settings sheet, and presenting from a VC that is
+        // already presenting fails silently.
+        var top = root
+        while let presented = top.presentedViewController { top = presented }
         self.onReward = onReward
         self.onDismiss = onDismiss
-        ad.present(from: root) { [weak self] in
+        self.onPresentFailure = onPresentFailure
+        ad.present(from: top) { [weak self] in
             self?.onReward?()
             self?.onReward = nil
         }
@@ -68,16 +78,22 @@ class RewardedAdManager: NSObject, ObservableObject, FullScreenContentDelegate {
         rewardedAd = nil
         isReady = false
         onDismiss?()
-        onDismiss = nil
+        clearCallbacks()
         preload()
     }
 
     func ad(_ ad: FullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
+        print("[RewardedAd] failed to present: \(error.localizedDescription)")
         rewardedAd = nil
         isReady = false
-        onReward = nil
-        onDismiss?()
-        onDismiss = nil
+        onPresentFailure?()
+        clearCallbacks()
         preload()
+    }
+
+    private func clearCallbacks() {
+        onReward = nil
+        onDismiss = nil
+        onPresentFailure = nil
     }
 }

--- a/RewardedAdManager.swift
+++ b/RewardedAdManager.swift
@@ -17,6 +17,7 @@ class RewardedAdManager: NSObject, ObservableObject, FullScreenContentDelegate {
 
     private var rewardedAd: RewardedAd?
     private var onReward: (() -> Void)?
+    private var onDismiss: (() -> Void)?
 
     override init() {
         super.init()
@@ -39,8 +40,9 @@ class RewardedAdManager: NSObject, ObservableObject, FullScreenContentDelegate {
 
     /// Shows the rewarded ad. Returns false if no ad is available
     /// (caller decides whether to grant the unlock anyway).
+    /// `onDismiss` fires after the ad closes — safe point to present UI.
     @discardableResult
-    func show(onReward: @escaping () -> Void) -> Bool {
+    func show(onReward: @escaping () -> Void, onDismiss: (() -> Void)? = nil) -> Bool {
         guard let ad = rewardedAd,
               let root = UIApplication.shared
                 .connectedScenes
@@ -52,6 +54,7 @@ class RewardedAdManager: NSObject, ObservableObject, FullScreenContentDelegate {
             return false
         }
         self.onReward = onReward
+        self.onDismiss = onDismiss
         ad.present(from: root) { [weak self] in
             self?.onReward?()
             self?.onReward = nil
@@ -64,6 +67,8 @@ class RewardedAdManager: NSObject, ObservableObject, FullScreenContentDelegate {
     func adDidDismissFullScreenContent(_ ad: FullScreenPresentingAd) {
         rewardedAd = nil
         isReady = false
+        onDismiss?()
+        onDismiss = nil
         preload()
     }
 
@@ -71,6 +76,8 @@ class RewardedAdManager: NSObject, ObservableObject, FullScreenContentDelegate {
         rewardedAd = nil
         isReady = false
         onReward = nil
+        onDismiss?()
+        onDismiss = nil
         preload()
     }
 }

--- a/RewardedAdManager.swift
+++ b/RewardedAdManager.swift
@@ -5,10 +5,7 @@ import UIKit
 @MainActor
 class RewardedAdManager: NSObject, ObservableObject, FullScreenContentDelegate {
 
-    // TODO: replace with a real REWARDED ad unit created in the AdMob console
-    // (no rewarded unit exists yet for pub-7871017136061682). This is Google's
-    // official test ID — it serves test ads and earns nothing.
-    private let adUnitID = "ca-app-pub-3940256099942544/1712485313"
+    private let adUnitID = "ca-app-pub-7871017136061682/5611090338"
 
     @Published private(set) var isReady = false
 

--- a/SettingsView.swift
+++ b/SettingsView.swift
@@ -14,6 +14,10 @@ struct SettingsView: View {
     @StateObject private var rewardedAd = RewardedAdManager()
     @Environment(\.dismiss) private var dismiss
 
+    @State private var pendingUnlock: (id: String, provider: TTSProvider, isCreole: Bool)?
+    @State private var showUnlockPrompt = false
+    @State private var showUnlockedConfirmation = false
+
     init(voiceSettings: VoiceSettings, ttsManager: TextToSpeechManager) {
         self.voiceSettings = voiceSettings
         self.ttsManager = ttsManager
@@ -28,6 +32,17 @@ struct SettingsView: View {
             }
             .navigationTitle("Voice Settings")
             .navigationBarTitleDisplayMode(.inline)
+            .alert("Unlock Premium Voices", isPresented: $showUnlockPrompt) {
+                Button("Watch Ad") { startUnlock() }
+                Button("Not Now", role: .cancel) { pendingUnlock = nil }
+            } message: {
+                Text("Watch a short ad to unlock all premium voices for 24 hours.")
+            }
+            .alert("Premium Voices Unlocked 🎉", isPresented: $showUnlockedConfirmation) {
+                Button("OK") {}
+            } message: {
+                Text("All premium voices are yours for the next 24 hours. After that, watch another short ad to unlock them again.")
+            }
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Done") { dismiss() }
@@ -118,7 +133,7 @@ struct SettingsView: View {
                             .font(.caption)
                     }
                     if voiceSettings.premiumVoicesUnlocked {
-                        Text("Premium voices unlocked ✓")
+                        Text("Premium voices unlocked ✓ \(unlockTimeRemaining) left")
                             .font(.caption)
                     } else {
                         Text("Watch one short ad to unlock all premium voices for 24 hours.")
@@ -233,16 +248,32 @@ struct SettingsView: View {
             setVoice(id, provider: provider, isCreole: isCreole)
             return
         }
-        let shown = rewardedAd.show {
-            voiceSettings.unlockPremiumVoices()
-            setVoice(id, provider: provider, isCreole: isCreole)
-            Analytics.logEvent("premium_voices_unlocked", parameters: ["via": "rewarded_ad", "voice": id])
-        }
+        pendingUnlock = (id, provider, isCreole)
+        showUnlockPrompt = true
+    }
+
+    private func startUnlock() {
+        guard let pending = pendingUnlock else { return }
+        pendingUnlock = nil
+        var earned = false
+        let shown = rewardedAd.show(
+            onReward: {
+                earned = true
+                voiceSettings.unlockPremiumVoices()
+                setVoice(pending.id, provider: pending.provider, isCreole: pending.isCreole)
+                Analytics.logEvent("premium_voices_unlocked", parameters: ["via": "rewarded_ad", "voice": pending.id])
+            },
+            onDismiss: {
+                // Confirmation must wait until the ad is off screen.
+                if earned { showUnlockedConfirmation = true }
+            }
+        )
         // No fill / not loaded yet — don't block the user on a missing ad.
         if !shown {
             voiceSettings.unlockPremiumVoices()
-            setVoice(id, provider: provider, isCreole: isCreole)
-            Analytics.logEvent("premium_voices_unlocked", parameters: ["via": "no_fill", "voice": id])
+            setVoice(pending.id, provider: pending.provider, isCreole: pending.isCreole)
+            Analytics.logEvent("premium_voices_unlocked", parameters: ["via": "no_fill", "voice": pending.id])
+            showUnlockedConfirmation = true
         }
     }
 
@@ -262,6 +293,11 @@ struct SettingsView: View {
             else        { voiceSettings.englishOpenAIVoice = id }
         case .system: break
         }
+    }
+
+    private var unlockTimeRemaining: String {
+        let hours = Int(((voiceSettings.premiumVoicesUnlockedUntil - Date().timeIntervalSince1970) / 3600).rounded(.up))
+        return hours <= 1 ? "less than 1 hour" : "\(hours) hours"
     }
 
     private func speedLabel(_ s: Double) -> String {

--- a/SettingsView.swift
+++ b/SettingsView.swift
@@ -5,6 +5,7 @@
 //  Per-language voice provider, voice selection, playback speed, and test buttons.
 //
 
+import FirebaseAnalytics
 import SwiftUI
 
 struct SettingsView: View {
@@ -235,11 +236,13 @@ struct SettingsView: View {
         let shown = rewardedAd.show {
             voiceSettings.unlockPremiumVoices()
             setVoice(id, provider: provider, isCreole: isCreole)
+            Analytics.logEvent("premium_voices_unlocked", parameters: ["via": "rewarded_ad", "voice": id])
         }
         // No fill / not loaded yet — don't block the user on a missing ad.
         if !shown {
             voiceSettings.unlockPremiumVoices()
             setVoice(id, provider: provider, isCreole: isCreole)
+            Analytics.logEvent("premium_voices_unlocked", parameters: ["via": "no_fill", "voice": id])
         }
     }
 

--- a/SettingsView.swift
+++ b/SettingsView.swift
@@ -255,26 +255,39 @@ struct SettingsView: View {
     private func startUnlock() {
         guard let pending = pendingUnlock else { return }
         pendingUnlock = nil
-        var earned = false
-        let shown = rewardedAd.show(
-            onReward: {
-                earned = true
-                voiceSettings.unlockPremiumVoices()
-                setVoice(pending.id, provider: pending.provider, isCreole: pending.isCreole)
-                Analytics.logEvent("premium_voices_unlocked", parameters: ["via": "rewarded_ad", "voice": pending.id])
-            },
-            onDismiss: {
-                // Confirmation must wait until the ad is off screen.
-                if earned { showUnlockedConfirmation = true }
+        // Wait for the alert's dismiss animation — presenting the ad while
+        // the alert is still on screen makes present() fail silently.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+            var earned = false
+            let shown = rewardedAd.show(
+                onReward: {
+                    earned = true
+                    voiceSettings.unlockPremiumVoices()
+                    setVoice(pending.id, provider: pending.provider, isCreole: pending.isCreole)
+                    Analytics.logEvent("premium_voices_unlocked", parameters: ["via": "rewarded_ad", "voice": pending.id])
+                },
+                onDismiss: {
+                    // Confirmation must wait until the ad is off screen.
+                    if earned { showUnlockedConfirmation = true }
+                },
+                onPresentFailure: {
+                    // User already agreed to watch — don't punish an SDK
+                    // presentation failure by keeping voices locked.
+                    grantUnlock(pending, via: "present_failed")
+                }
+            )
+            // No fill / not loaded yet — don't block the user on a missing ad.
+            if !shown {
+                grantUnlock(pending, via: "no_fill")
             }
-        )
-        // No fill / not loaded yet — don't block the user on a missing ad.
-        if !shown {
-            voiceSettings.unlockPremiumVoices()
-            setVoice(pending.id, provider: pending.provider, isCreole: pending.isCreole)
-            Analytics.logEvent("premium_voices_unlocked", parameters: ["via": "no_fill", "voice": pending.id])
-            showUnlockedConfirmation = true
         }
+    }
+
+    private func grantUnlock(_ pending: (id: String, provider: TTSProvider, isCreole: Bool), via: String) {
+        voiceSettings.unlockPremiumVoices()
+        setVoice(pending.id, provider: pending.provider, isCreole: pending.isCreole)
+        Analytics.logEvent("premium_voices_unlocked", parameters: ["via": via, "voice": pending.id])
+        showUnlockedConfirmation = true
     }
 
     private func selectedVoiceId(provider: TTSProvider, isCreole: Bool) -> String {

--- a/SettingsView.swift
+++ b/SettingsView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct SettingsView: View {
     @ObservedObject var voiceSettings: VoiceSettings
     @ObservedObject var ttsManager: TextToSpeechManager
+    @ObservedObject var privacyConsent: DataPrivacyConsent
     @StateObject private var rewardedAd = RewardedAdManager()
     @Environment(\.dismiss) private var dismiss
 
@@ -19,9 +20,10 @@ struct SettingsView: View {
     @State private var showUnlockedConfirmation = false
     @State private var isUnlocking = false
 
-    init(voiceSettings: VoiceSettings, ttsManager: TextToSpeechManager) {
+    init(voiceSettings: VoiceSettings, ttsManager: TextToSpeechManager, privacyConsent: DataPrivacyConsent) {
         self.voiceSettings = voiceSettings
         self.ttsManager = ttsManager
+        self.privacyConsent = privacyConsent
     }
 
     var body: some View {
@@ -30,6 +32,7 @@ struct SettingsView: View {
                 languageSection(isCreole: false)
                 languageSection(isCreole: true)
                 testSection
+                privacySection
             }
             .navigationTitle("Voice Settings")
             .navigationBarTitleDisplayMode(.inline)
@@ -245,6 +248,27 @@ struct SettingsView: View {
         }
     }
 
+    // MARK: - Privacy section
+
+    private var privacySection: some View {
+        Section {
+            Link(destination: URL(string: "https://jbaker00.github.io/CreoleTranslator-iOS/privacy-policy")!) {
+                Label("Privacy Policy", systemImage: "doc.text")
+            }
+            Button(role: .destructive) {
+                privacyConsent.revokeConsent()
+                dismiss()
+            } label: {
+                Label("Revoke AI Data Consent", systemImage: "hand.raised")
+            }
+        } header: {
+            Label("Privacy", systemImage: "lock.shield")
+        } footer: {
+            Text("Revoking consent disables recording and translation until you consent again.")
+                .font(.caption)
+        }
+    }
+
     // MARK: - Helpers
 
     private func selectVoice(_ id: String, locked: Bool, provider: TTSProvider, isCreole: Bool) {
@@ -343,6 +367,7 @@ struct SettingsView: View {
 #Preview {
     SettingsView(
         voiceSettings: VoiceSettings(),
-        ttsManager: TextToSpeechManager()
+        ttsManager: TextToSpeechManager(),
+        privacyConsent: DataPrivacyConsent()
     )
 }

--- a/SettingsView.swift
+++ b/SettingsView.swift
@@ -17,6 +17,7 @@ struct SettingsView: View {
     @State private var pendingUnlock: (id: String, provider: TTSProvider, isCreole: Bool)?
     @State private var showUnlockPrompt = false
     @State private var showUnlockedConfirmation = false
+    @State private var isUnlocking = false
 
     init(voiceSettings: VoiceSettings, ttsManager: TextToSpeechManager) {
         self.voiceSettings = voiceSettings
@@ -32,16 +33,16 @@ struct SettingsView: View {
             }
             .navigationTitle("Voice Settings")
             .navigationBarTitleDisplayMode(.inline)
-            .alert("Unlock Premium Voices", isPresented: $showUnlockPrompt) {
+            .alert("Unlock Extra Voices", isPresented: $showUnlockPrompt) {
                 Button("Watch Ad") { startUnlock() }
                 Button("Not Now", role: .cancel) { pendingUnlock = nil }
             } message: {
-                Text("Watch a short ad to unlock all premium voices for 24 hours.")
+                Text("Watch one short ad. All voices free for 24 hours.\n\nGade yon ti piblisite. Tout vwa yo gratis pou 24 èdtan.")
             }
-            .alert("Premium Voices Unlocked 🎉", isPresented: $showUnlockedConfirmation) {
+            .alert("Voices Unlocked", isPresented: $showUnlockedConfirmation) {
                 Button("OK") {}
             } message: {
-                Text("All premium voices are yours for the next 24 hours. After that, watch another short ad to unlock them again.")
+                Text("All voices are free for the next 24 hours.\n\nTout vwa yo gratis pou pwochen 24 èdtan yo.")
             }
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
@@ -95,7 +96,8 @@ struct SettingsView: View {
 
             Section {
                 ForEach(voices) { voice in
-                    let locked = voiceSettings.isVoiceLocked(voice.id) && voice.id != selectedId
+                    let inAdTier = voiceSettings.isVoiceLocked(voice.id)
+                    let locked = inAdTier && voice.id != selectedId
                     Button {
                         selectVoice(voice.id, locked: locked, provider: provider, isCreole: isCreole)
                     } label: {
@@ -111,7 +113,9 @@ struct SettingsView: View {
                                             .foregroundColor(.orange)
                                     }
                                 }
-                                Text(locked ? "Premium — watch a short ad to unlock" : voice.description)
+                                Text(locked ? "Free with a short ad"
+                                     : inAdTier ? "Your current voice — always available"
+                                     : voice.description)
                                     .font(.caption)
                                     .foregroundColor(locked ? .orange : .secondary)
                             }
@@ -133,10 +137,10 @@ struct SettingsView: View {
                             .font(.caption)
                     }
                     if voiceSettings.premiumVoicesUnlocked {
-                        Text("Premium voices unlocked ✓ \(unlockTimeRemaining) left")
+                        Text("All voices unlocked ✓ \(unlockTimeRemaining) left")
                             .font(.caption)
                     } else {
-                        Text("Watch one short ad to unlock all premium voices for 24 hours.")
+                        Text("Extra voices are free for 24 hours after one short ad.")
                             .font(.caption)
                     }
                 }
@@ -248,16 +252,26 @@ struct SettingsView: View {
             setVoice(id, provider: provider, isCreole: isCreole)
             return
         }
+        guard !isUnlocking else { return }
         pendingUnlock = (id, provider, isCreole)
         showUnlockPrompt = true
     }
 
     private func startUnlock() {
-        guard let pending = pendingUnlock else { return }
+        guard let pending = pendingUnlock, !isUnlocking else { return }
         pendingUnlock = nil
-        // Wait for the alert's dismiss animation — presenting the ad while
-        // the alert is still on screen makes present() fail silently.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+        isUnlocking = true
+        Task { @MainActor in
+            // Wait for the alert's dismiss animation — presenting the ad
+            // while the alert is still on screen fails silently.
+            try? await Task.sleep(nanoseconds: 600_000_000)
+            // The manager preloads when the sheet opens; give a slow network
+            // up to 3s before falling back to a free grant.
+            var waitedNs: UInt64 = 0
+            while !rewardedAd.isReady && waitedNs < 3_000_000_000 {
+                try? await Task.sleep(nanoseconds: 250_000_000)
+                waitedNs += 250_000_000
+            }
             var earned = false
             let shown = rewardedAd.show(
                 onReward: {
@@ -267,6 +281,7 @@ struct SettingsView: View {
                     Analytics.logEvent("premium_voices_unlocked", parameters: ["via": "rewarded_ad", "voice": pending.id])
                 },
                 onDismiss: {
+                    isUnlocking = false
                     // Confirmation must wait until the ad is off screen.
                     if earned { showUnlockedConfirmation = true }
                 },
@@ -276,7 +291,7 @@ struct SettingsView: View {
                     grantUnlock(pending, via: "present_failed")
                 }
             )
-            // No fill / not loaded yet — don't block the user on a missing ad.
+            // Still no ad after waiting — don't block the user on a missing ad.
             if !shown {
                 grantUnlock(pending, via: "no_fill")
             }
@@ -284,6 +299,7 @@ struct SettingsView: View {
     }
 
     private func grantUnlock(_ pending: (id: String, provider: TTSProvider, isCreole: Bool), via: String) {
+        isUnlocking = false
         voiceSettings.unlockPremiumVoices()
         setVoice(pending.id, provider: pending.provider, isCreole: pending.isCreole)
         Analytics.logEvent("premium_voices_unlocked", parameters: ["via": via, "voice": pending.id])

--- a/SettingsView.swift
+++ b/SettingsView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct SettingsView: View {
     @ObservedObject var voiceSettings: VoiceSettings
     @ObservedObject var ttsManager: TextToSpeechManager
+    @StateObject private var rewardedAd = RewardedAdManager()
     @Environment(\.dismiss) private var dismiss
 
     init(voiceSettings: VoiceSettings, ttsManager: TextToSpeechManager) {
@@ -78,17 +79,25 @@ struct SettingsView: View {
 
             Section {
                 ForEach(voices) { voice in
+                    let locked = voiceSettings.isVoiceLocked(voice.id) && voice.id != selectedId
                     Button {
-                        setVoice(voice.id, provider: provider, isCreole: isCreole)
+                        selectVoice(voice.id, locked: locked, provider: provider, isCreole: isCreole)
                     } label: {
                         HStack {
                             VStack(alignment: .leading, spacing: 2) {
-                                Text(voice.name)
-                                    .font(.body)
-                                    .foregroundColor(.primary)
-                                Text(voice.description)
+                                HStack(spacing: 6) {
+                                    Text(voice.name)
+                                        .font(.body)
+                                        .foregroundColor(.primary)
+                                    if locked {
+                                        Image(systemName: "lock.fill")
+                                            .font(.caption)
+                                            .foregroundColor(.orange)
+                                    }
+                                }
+                                Text(locked ? "Premium — watch a short ad to unlock" : voice.description)
                                     .font(.caption)
-                                    .foregroundColor(.secondary)
+                                    .foregroundColor(locked ? .orange : .secondary)
                             }
                             Spacer()
                             if voice.id == selectedId {
@@ -102,9 +111,18 @@ struct SettingsView: View {
             } header: {
                 Text("Choose \(langName) Voice")
             } footer: {
-                if provider == .groq {
-                    Text("Groq Orpheus has a 200 character limit per utterance.")
-                        .font(.caption)
+                VStack(alignment: .leading, spacing: 4) {
+                    if provider == .groq {
+                        Text("Groq Orpheus has a 200 character limit per utterance.")
+                            .font(.caption)
+                    }
+                    if voiceSettings.premiumVoicesUnlocked {
+                        Text("Premium voices unlocked ✓")
+                            .font(.caption)
+                    } else {
+                        Text("Watch one short ad to unlock all premium voices for 24 hours.")
+                            .font(.caption)
+                    }
                 }
             }
         }
@@ -208,6 +226,22 @@ struct SettingsView: View {
     }
 
     // MARK: - Helpers
+
+    private func selectVoice(_ id: String, locked: Bool, provider: TTSProvider, isCreole: Bool) {
+        guard locked else {
+            setVoice(id, provider: provider, isCreole: isCreole)
+            return
+        }
+        let shown = rewardedAd.show {
+            voiceSettings.unlockPremiumVoices()
+            setVoice(id, provider: provider, isCreole: isCreole)
+        }
+        // No fill / not loaded yet — don't block the user on a missing ad.
+        if !shown {
+            voiceSettings.unlockPremiumVoices()
+            setVoice(id, provider: provider, isCreole: isCreole)
+        }
+    }
 
     private func selectedVoiceId(provider: TTSProvider, isCreole: Bool) -> String {
         switch provider {

--- a/VoiceSettings.swift
+++ b/VoiceSettings.swift
@@ -63,6 +63,29 @@ class VoiceSettings: ObservableObject {
         Voice(id: "shimmer", name: "Shimmer", description: "Soft & gentle (female)"),
     ]
 
+    // MARK: - Premium voice unlock (rewarded ad)
+
+    // Default voices stay free; the rest are "premium" and unlock for 24h
+    // after watching a rewarded ad. Already-selected voices are grandfathered
+    // (the gate applies at selection time only).
+    static let freeVoiceIds: Set<String> = ["diana", "alloy"]
+    static let premiumUnlockHours: Double = 24
+
+    @AppStorage("premiumVoicesUnlockedUntil") var premiumVoicesUnlockedUntil: Double = 0
+
+    var premiumVoicesUnlocked: Bool {
+        Date().timeIntervalSince1970 < premiumVoicesUnlockedUntil
+    }
+
+    func unlockPremiumVoices() {
+        premiumVoicesUnlockedUntil = Date().timeIntervalSince1970 + Self.premiumUnlockHours * 3600
+        objectWillChange.send()
+    }
+
+    func isVoiceLocked(_ id: String) -> Bool {
+        !Self.freeVoiceIds.contains(id) && !premiumVoicesUnlocked
+    }
+
     // MARK: - Helpers
 
     /// Providers valid for English

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -6,7 +6,7 @@ title: Privacy Policy — Creole Translator
 # Privacy Policy
 
 **Creole Translator**
-*Last Updated: March 8, 2026*
+*Last Updated: July 3, 2026*
 
 ## Overview
 
@@ -27,8 +27,9 @@ When you use the App's recording feature, your voice is captured by your device'
 
 When you use the "speak" feature to hear a translation read aloud:
 
-- The translated text is sent to **Groq AI** to generate speech audio.
-- Text is transmitted over an encrypted HTTPS connection and is not stored on your device after playback.
+- English text is sent to **Groq AI** and Haitian Creole text is sent to **OpenAI** to generate speech audio, depending on the voice you select.
+- Text is transmitted over an encrypted HTTPS connection. The generated audio is not stored after playback.
+- Please review [OpenAI's Privacy Policy](https://openai.com/policies/privacy-policy/) for details on how they handle submitted data.
 
 ### Analytics
 
@@ -42,7 +43,7 @@ Firebase Analytics does **not** collect the content of your speech or translatio
 
 ### Advertising
 
-The App displays banner advertisements served by **Google AdMob**. AdMob may use device identifiers and other information to serve personalized or non-personalized ads, subject to your App Tracking Transparency (ATT) preference on your device. Review [Google's Advertising Privacy Policy](https://policies.google.com/technologies/ads) for more detail.
+The App displays advertisements served by **Google AdMob**: banner ads, occasional full-screen interstitial ads between translations, and optional rewarded ads you can choose to watch to unlock extra voices. AdMob may use device identifiers and other information to serve personalized or non-personalized ads, subject to your App Tracking Transparency (ATT) preference on your device. Review [Google's Advertising Privacy Policy](https://policies.google.com/technologies/ads) for more detail.
 
 ## Microphone Permission
 
@@ -51,7 +52,7 @@ The App requires microphone access to record your speech. You will be prompted t
 ## Data Retention
 
 - **Audio:** Not stored on your device after processing. Groq AI's retention practices are governed by their own privacy policy.
-- **Translation history:** Stored locally on your device only. It is never transmitted to any server.
+- **Translation history:** Transcribed and translated text is saved to your on-device history (up to 50 entries). It is stored locally only and never transmitted to any server. You can clear it in the App at any time.
 - **Analytics:** Retained by Firebase per Google's standard data retention settings.
 
 ## Children's Privacy
@@ -69,7 +70,8 @@ The App is not directed at children under 13. We do not knowingly collect person
 
 | Service | Purpose | Privacy Policy |
 |---|---|---|
-| Groq AI | Speech transcription, translation, text-to-speech | [groq.com/privacy-policy](https://groq.com/privacy-policy/) |
+| Groq AI | Speech transcription, translation, English text-to-speech | [groq.com/privacy-policy](https://groq.com/privacy-policy/) |
+| OpenAI | Haitian Creole text-to-speech | [openai.com/policies/privacy-policy](https://openai.com/policies/privacy-policy/) |
 | Google Firebase | Analytics and crash reporting | [policies.google.com/privacy](https://policies.google.com/privacy) |
 | Google AdMob | In-app advertising | [policies.google.com/technologies/ads](https://policies.google.com/technologies/ads) |
 


### PR DESCRIPTION
## Summary

Everything needed to lift CreoleTranslator's ad revenue plus the analytics to measure it:

**Ad load**
- Interstitials: every 4 translations (was 25), capped at 6/session, ≥120s apart; session counters reset after 30 min in background; skipped opportunities (e.g. while TTS is speaking) retry on the next translation
- New rewarded ad: premium AI voices (all except `diana`/`alloy`) unlock for 24h after watching an ad; no-fill or presentation failure still grants the unlock so users are never blocked
- DEBUG builds use Google's test rewarded unit (new production units take hours to serve); release uses `CreoleTranslatorRewarded`

**Unlock UX**
- Pre-ad confirmation alert ("watch a short ad to unlock all premium voices for 24 hours"), post-ad "unlocked 🎉" confirmation, and the voice list footer shows hours remaining
- Fixed rewarded ad never presenting: present from the top-most VC (settings is a sheet) after the alert dismisses

**First-launch flow**
- Prompts no longer stack: privacy consent sheet first, ATT right after consent (keeps banner requests personalized), microphone prompt on first record tap

**App Store audit fixes (Guidelines 5.1.1, 5.1.2, 2.1)**
- Privacy policy updated: discloses OpenAI TTS, all three ad formats (banner/interstitial/rewarded), and on-device translation history retention — goes live on GitHub Pages (main/docs) when this merges
- Settings gains a Privacy section: policy link + working "Revoke AI Data Consent" button, backing the policy's revocation promise
- Consent sheet copy names both Groq and OpenAI
- Removed unused NSSpeechRecognitionUsageDescription

**Analytics (feeds the FirebaseViewer Usage tab)**
- `translation_completed` / `translation_failed` (direction + input_mode), `interstitial_shown`, `premium_voices_unlocked` (via rewarded_ad / no_fill / present_failed), screen_view for history/settings

**Release prep**
- Marketing version 2.95

## Test plan
- [x] Build passes
- [x] Rewarded ad presents from settings sheet (test unit, simulator)
- [ ] Verify production rewarded unit serves once AdMob warms up
- [ ] First-run on clean install: consent → ATT → mic-on-record sequence
- [ ] Revoke consent in Settings → recording disabled → consent sheet re-appears
- [ ] Events visible in FirebaseViewer Usage tab ~24h after release
- [ ] After merge: confirm https://jbaker00.github.io/CreoleTranslator-iOS/privacy-policy shows July 3, 2026 date

🤖 Generated with [Claude Code](https://claude.com/claude-code)